### PR TITLE
Added changes for Debian (+ PHP version check)

### DIFF
--- a/install/ubuntu-14-04-x.sh
+++ b/install/ubuntu-14-04-x.sh
@@ -76,7 +76,14 @@ echo
 
 echo " * Setting up PHP & Apache"
 echo
-add-apt-repository ppa:ondrej/php5-5.6 -y
+PHPVER=$(php -r 'echo (version_compare(phpversion(), "5.6") >= 0);');
+
+if [ ! $PHPVER ]
+then
+    sudo apt-get install software-properties-common -y
+    add-apt-repository ppa:ondrej/php5-5.6 -y
+fi
+
 apt-get update
 apt-get install apache2 php5 php5-cli php5-mcrypt php5-intl php5-mysql php5-curl php5-gd -y
 

--- a/install/ubuntu-14-04-x.sh
+++ b/install/ubuntu-14-04-x.sh
@@ -76,9 +76,7 @@ echo
 
 echo " * Setting up PHP & Apache"
 echo
-PHPVER=$(php -r 'echo (version_compare(phpversion(), "5.6") >= 0);');
-
-if [ ! $PHPVER ]
+if ! command -v php || ! php -r 'echo (version_compare(phpversion(), "5.6") >= 0);'
 then
     sudo apt-get install software-properties-common -y
     add-apt-repository ppa:ondrej/php5-5.6 -y


### PR DESCRIPTION
Just a little fix for the script that might have gotten some users stuck in other Debian distributions than Ubuntu.

Debian does not have the command "add-apt-repository" pre-installed which might also be the case for other distributions, so executing "sudo apt-get install software-properties-common -y" is a requirement for the script to work on all Debian distributions besides Ubuntu. With this little addition the script won't cancel at this point and will work for Debian 8 and Ubuntu 14.04 (tested).

Also added a check for the PHP version, so the repository "ppa:ondrej/php5-5.6" will not be added to the list, if a newer version of PHP is already installed on the system. If the repository is not needed, then the requirements for the "add-apt-repository" command won't be added unnecessarily either. The value of the PHPVER variable will be "false" both if PHP is not installed or a lower version than "5.6" is detected and only then install the "add-apt-repository" command and add the repository to the list.