### PR TITLE
Update Debian 8 & Ubuntu 16.04, add Debian 9 install scripts.

### DIFF
--- a/install/debian-8-x.sh
+++ b/install/debian-8-x.sh
@@ -22,8 +22,8 @@ sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/
 wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 
 echo " * Adding MariaDB repostitory & GPG signing key"
-sh -c 'echo "deb [arch=amd64,i386] http://mirrors.ukfast.co.uk/sites/mariadb/repo/10.2/debian jessie main" > /etc/apt/sources.list.d/mariadb.list'
-apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db
+sh -c 'echo "deb http://downloads.mariadb.com/MariaDB/mariadb-10.2/repo/debian $(lsb_release -sc) main" > /etc/apt/sources.list.d/mariadb.list'
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xcbcb082a1bb943db 0xF1656F24C74CD1D8
 
 echo " * Updating repolist"
 apt update

--- a/install/debian-9-x.sh
+++ b/install/debian-9-x.sh
@@ -22,8 +22,8 @@ sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/
 wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 
 echo " * Adding MariaDB repostitory & GPG signing key"
-sh -c 'echo "deb [arch=amd64,i386] http://mirrors.ukfast.co.uk/sites/mariadb/repo/10.2/debian jessie main" > /etc/apt/sources.list.d/mariadb.list'
-apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db
+sh -c 'echo "deb [arch=amd64,i386,ppc64el] http://mirrors.ukfast.co.uk/sites/mariadb/repo/10.2/debian stretch main" > /etc/apt/sources.list.d/mariadb.list'
+apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xF1656F24C74CD1D8
 
 echo " * Updating repolist"
 apt update

--- a/install/debian-9-x.sh
+++ b/install/debian-9-x.sh
@@ -22,8 +22,8 @@ sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/
 wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 
 echo " * Adding MariaDB repostitory & GPG signing key"
-sh -c 'echo "deb [arch=amd64,i386,ppc64el] http://mirrors.ukfast.co.uk/sites/mariadb/repo/10.2/debian stretch main" > /etc/apt/sources.list.d/mariadb.list'
-apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xF1656F24C74CD1D8
+sh -c 'echo "deb http://downloads.mariadb.com/MariaDB/mariadb-10.2/repo/debian $(lsb_release -sc) main" > /etc/apt/sources.list.d/mariadb.list'
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xcbcb082a1bb943db 0xF1656F24C74CD1D8
 
 echo " * Updating repolist"
 apt update

--- a/install/installer.sh
+++ b/install/installer.sh
@@ -5,7 +5,7 @@
 echo ' * SeAT Installer Operating System Selection'
 
 PS3=' * Please select the target operating system: '
-options=("CentOS 6" "CentOS 7" "Ubuntu 16x" "Debian 8x" "Quit")
+options=("CentOS 6" "CentOS 7" "Ubuntu 16x" "Debian 8x" "Debian 9x" "Quit")
 select opt in "${options[@]}"
 do
     case $opt in
@@ -27,6 +27,11 @@ do
         "Debian 8x")
             echo ' * Downloading and running Debian 8x installer'
             bash <(curl -fsSL https://raw.githubusercontent.com/eveseat/scripts/master/install/debian-8-x.sh)
+            break
+            ;;
+        "Debian 9x")
+            echo ' * Downloading and running Debian 9x installer'
+            bash <(curl -fsSL https://raw.githubusercontent.com/eveseat/scripts/master/install/debian-9-x.sh)
             break
             ;;
         "Quit")

--- a/install/ubuntu-16-x.sh
+++ b/install/ubuntu-16-x.sh
@@ -15,6 +15,8 @@ cd /root/
 export DEBIAN_FRONTEND=noninteractive
 
 apt update
+echo " * Ensuring we have all the prerequisites for the SeAT tool installer"
+apt install apt-transport-https ca-certificates curl software-properties-common -y
 LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C
 


### PR DESCRIPTION
Changes as per title. These changes will need to be merged in conjunction with my PR for the SeAT installer (https://github.com/eveseat/installer/pull/5).

If you have any further changes you would like me to make, please let me know.