### PR TITLE
Add Ubuntu 18.04 LTS support, fix CentOS 6 support

### DIFF
--- a/install/centos-6-x.sh
+++ b/install/centos-6-x.sh
@@ -53,7 +53,7 @@ EOT
 echo " * Configuring MariaDB 10.2 GPG"
 rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 
-echo " * Enabling Remi php 7.1 repository"
+echo " * Enabling repos"
 yum install yum-utils -y
 yum-config-manager --enable remi-php71,gf-plus
 

--- a/install/centos-6-x.sh
+++ b/install/centos-6-x.sh
@@ -31,6 +31,14 @@ REMI=remi-release-6.rpm && curl -O http://rpms.remirepo.net/enterprise/$REMI && 
 echo " * Configuring Remi GPG"
 rpm --import http://rpms.remirepo.net/RPM-GPG-KEY-remi
 
+echo " * Installing Ghettoforge Repository"
+# Download and install the latest release
+GF=gf-release-latest.gf.el6.noarch.rpm && curl -O http://mirror.ghettoforge.org/distributions/gf/$GF && yum localinstall -y $GF && rm -f $GF
+
+echo " * Configuring Ghettoforge GPG"
+# Import the GhettoForge signing keys
+rpm --import "http://mirror.ghettoforge.org/distributions/gf/RPM-GPG-KEY-gf.el6"
+
 echo " * Installing MariaDB 10.2 Repository"
 cat <<EOT >> /etc/yum.repos.d/MariaDB.repo
 # MariaDB 10.2 CentOS repository list - created 2018-05-12 15:58 UTC
@@ -47,7 +55,7 @@ rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 
 echo " * Enabling Remi php 7.1 repository"
 yum install yum-utils -y
-yum-config-manager --enable remi-php71
+yum-config-manager --enable remi-php71,gf-plus
 
 echo " * Running yum clean all"
 yum clean all

--- a/install/centos-6-x.sh
+++ b/install/centos-6-x.sh
@@ -53,9 +53,9 @@ EOT
 echo " * Configuring MariaDB 10.2 GPG"
 rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 
-echo " * Enabling repos"
+echo " * Enabling Remi PHP 7.1 repository"
 yum install yum-utils -y
-yum-config-manager --enable remi-php71,gf-plus
+yum-config-manager --enable remi-php71
 
 echo " * Running yum clean all"
 yum clean all

--- a/install/centos-6-x.sh
+++ b/install/centos-6-x.sh
@@ -61,7 +61,7 @@ echo " * Running yum clean all"
 yum clean all
 
 echo " * Installing installer dependencies"
-yum install -y php-cli php-mysql php-posix git unzip
+yum install -y php-cli php-mysqlnd php-posix git unzip
 
 echo " * Installing SeAT tool"
 curl -fsSL https://git.io/vXb0u -o /usr/local/bin/seat

--- a/install/centos-6-x.sh
+++ b/install/centos-6-x.sh
@@ -5,6 +5,13 @@ if [ $EUID != 0 ]; then
     exit 1
 fi
 
+OSARCH="$(getconf LONG_BIT)"
+if [ "$OSARCH" == "32" ]; then
+
+    echo " * ERROR: SeAT requires a 64bit OS!"
+    exit 1
+fi
+
 # Stop if any errors occur
 set -e
 
@@ -16,7 +23,7 @@ echo " * Installing EPEL Repository"
 EPEL=epel-release-latest-6.noarch.rpm && curl -O https://dl.fedoraproject.org/pub/epel/$EPEL && yum localinstall -y $EPEL && rm -f $EPEL
 
 echo " * Configuring EPEL GPG"
-rpm --import http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
+rpm --import "http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6"
 
 echo " * Installing Remi Repository"
 REMI=remi-release-6.rpm && curl -O http://rpms.remirepo.net/enterprise/$REMI && yum localinstall -y $REMI && rm -f $REMI
@@ -24,17 +31,26 @@ REMI=remi-release-6.rpm && curl -O http://rpms.remirepo.net/enterprise/$REMI && 
 echo " * Configuring Remi GPG"
 rpm --import http://rpms.remirepo.net/RPM-GPG-KEY-remi
 
-echo " * Installing Ghettoforge Repository"
-# Download and install the latest release
-GF=gf-release-6-10.gf.el6.noarch.rpm && curl -O http://mirror.symnds.com/distributions/gf/el/6/gf/x86_64/$GF && yum localinstall -y $GF && rm -f $GF
+echo " * Installing MariaDB 10.2 Repository"
+cat <<EOT >> /etc/yum.repos.d/MariaDB.repo
+# MariaDB 10.2 CentOS repository list - created 2018-05-12 15:58 UTC
+# http://downloads.mariadb.org/mariadb/repositories/
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/10.2/centos6-amd64
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1
+EOT
 
-echo " * Configuring Ghettoforge GPG"
-# Import the GhettoForge signing keys
-rpm --import http://mirror.symnds.com/distributions/gf/RPM-GPG-KEY-gf.el6
+echo " * Configuring MariaDB 10.2 GPG"
+rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 
-echo " * Enabling Repos"
+echo " * Enabling Remi php 7.1 repository"
 yum install yum-utils -y
-yum-config-manager --enable remi,remi-php70,gf-plus
+yum-config-manager --enable remi-php71
+
+echo " * Running yum clean all"
+yum clean all
 
 echo " * Installing installer dependencies"
 yum install -y php-cli php-mysql php-posix git unzip

--- a/install/centos-7-x.sh
+++ b/install/centos-7-x.sh
@@ -38,7 +38,7 @@ EOT
 echo " * Configuring MariaDB 10.2 GPG"
 rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 
-echo " * Enabling Remi php 7.1 repository"
+echo " * Enabling Remi PHP 7.1 repository"
 yum install yum-utils -y
 yum-config-manager --enable remi-php71
 

--- a/install/centos-7-x.sh
+++ b/install/centos-7-x.sh
@@ -38,7 +38,7 @@ EOT
 echo " * Configuring MariaDB 10.2 GPG"
 rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 
-echo " * Enabling Remi and php 7.1 repository"
+echo " * Enabling Remi php 7.1 repository"
 yum install yum-utils -y
 yum-config-manager --enable remi-php71
 

--- a/install/installer.sh
+++ b/install/installer.sh
@@ -25,7 +25,7 @@ do
             break
             ;;
         "Ubuntu 18x")
-            echo ' * Downloading and running Ubuntu 16x installer'
+            echo ' * Downloading and running Ubuntu 18x installer'
             bash <(curl -fsSL https://raw.githubusercontent.com/eveseat/scripts/master/install/ubuntu-18-x.sh)
             break
             ;;

--- a/install/installer.sh
+++ b/install/installer.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# 2016 Leon Jacobs
+# 2016-2018 Leon Jacobs & SeAT Contributors
 
 echo ' * SeAT Installer Operating System Selection'
 
 PS3=' * Please select the target operating system: '
-options=("CentOS 6" "CentOS 7" "Ubuntu 16x" "Debian 8x" "Debian 9x" "Quit")
+options=("CentOS 6" "CentOS 7" "Ubuntu 16x" "Ubuntu 18x" "Debian 8x" "Debian 9x" "Quit")
 select opt in "${options[@]}"
 do
     case $opt in
@@ -22,6 +22,11 @@ do
         "Ubuntu 16x")
             echo ' * Downloading and running Ubuntu 16x installer'
             bash <(curl -fsSL https://raw.githubusercontent.com/eveseat/scripts/master/install/ubuntu-16-x.sh)
+            break
+            ;;
+        "Ubuntu 18x")
+            echo ' * Downloading and running Ubuntu 16x installer'
+            bash <(curl -fsSL https://raw.githubusercontent.com/eveseat/scripts/master/install/ubuntu-18-x.sh)
             break
             ;;
         "Debian 8x")

--- a/install/ubuntu-18-x.sh
+++ b/install/ubuntu-18-x.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+if [ $EUID != 0 ]; then
+
+    echo " * ERROR: This script should be run as root!"
+    exit 1
+fi
+
+# Stop if any errors occur
+set -e
+
+# Work from roots home
+cd /root/
+
+# Make Ubuntu not ask any questions
+export DEBIAN_FRONTEND=noninteractive
+
+apt update
+echo " * Ensuring we have all the prerequisites for the SeAT tool installer"
+apt install apt-transport-https ca-certificates curl software-properties-common -y
+LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C
+
+echo " * Installing installer dependencies"
+apt install php7.1-cli php7.1-mysql unzip git -y
+
+echo " * Installing SeAT tool"
+curl -fsSL https://git.io/vXb0u -o /usr/local/bin/seat
+chmod +x /usr/local/bin/seat
+hash -r
+
+echo " * Installer download complete!"
+echo " * You can now run the seat tool by just running the 'seat' command."
+echo " * Start installing SeAT with: seat install:production"


### PR DESCRIPTION
As per title, this PR fixes CentOS 6 support for SeAT v3, and also adds support for Ubuntu 18.04 LTS to the install scripts.

To be merged with required Installer updates: https://github.com/eveseat/installer/pull/9