### PR TITLE
Adding my.cnf file to the docker-compose.yml and bootstrap.sh

### DIFF
--- a/docker-compose/bootstrap.sh
+++ b/docker-compose/bootstrap.sh
@@ -52,6 +52,7 @@ cd $SEAT_DOCKER_INSTALL
 echo "Grabbing docker-compose and .env file"
 curl -L https://raw.githubusercontent.com/eveseat/scripts/master/docker-compose/docker-compose.yml -o $SEAT_DOCKER_INSTALL/docker-compose.yml
 curl -L https://raw.githubusercontent.com/eveseat/scripts/master/docker-compose/.env -o $SEAT_DOCKER_INSTALL/.env
+curl -L https://raw.githubusercontent.com/eveseat/scripts/master/docker-compose/my.cnf -o $SEAT_DOCKER_INSTALL/my.cnf
 
 echo "Generating a random database password and writing it to the .env file."
 sed -i -- 's/DB_PASSWORD=i_should_be_changed/DB_PASSWORD='$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c22 ; echo '')'/g' .env

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       MYSQL_DATABASE: ${DB_DATABASE}
     volumes:
       - "mariadb-data:/var/lib/mysql"
+      - "./my.cnf:/etc/mysql/my.cnf"
     networks:
       - seat-network
     logging:

--- a/docker-compose/my.cnf
+++ b/docker-compose/my.cnf
@@ -1,0 +1,7 @@
+#my.cnf increase the values if you get a timeout error
+[mysqld]
+max_allowed_packet      = 1300M
+net_read_timeout        = 7200
+net_write_timeout       = 7200
+[mysqldump]
+max_allowed_packet      = 1300M


### PR DESCRIPTION
Adding the my.cnf to the docker-compose.yml and bootstrap.sh so it is possible to backup large databases and import large databases.