### PR TITLE
feat: ship seat with traefik

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -7,7 +7,7 @@
 APP_DEBUG=false
 
 # URL where your SeAT instance can be found from the Internet.
-APP_URL=http://localhost
+APP_URL=https://change.me
 
 # Eve Online SSO Configuration
 EVE_CLIENT_ID=null
@@ -45,17 +45,5 @@ MAIL_FROM_ADDRESS=noreply@localhost.local
 MAIL_FROM_NAME='SeAT Administrator'
 
 # - DOCKER Specific Configuration
-
-# External Ports
-# These are the local ports where the respective services will be available on.
-# The ports themselves are not the standard ports as you are encouraged to front
-# SeAT with your own nginx proxy & letsencrypt combination.
-NGINX_HTTP=8080
-NGINX_HTTPS=8443
-
-# Ngnix
-# If you are fronting this web server with a bare metal Nginx setup (which
-# you should) then there is no need to change this.
-NGINX_HOST=_
-#NGINX_HOST=foobar.com
-
+HOST=change.me
+ACME_EMAIL=change_me@example.com

--- a/docker-compose/bootstrap.sh
+++ b/docker-compose/bootstrap.sh
@@ -58,10 +58,27 @@ echo "Generating a random database password and writing it to the .env file."
 sed -i -- 's/DB_PASSWORD=i_should_be_changed/DB_PASSWORD='$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c22 ; echo '')'/g' .env
 echo "Generating an application key and writing it to the .env file."
 sed -i -- 's/APP_KEY=insecure/APP_KEY='$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c32 ; echo '')'/g' .env
+echo ""
+echo "Please provide a valid e-mail address. It will be used to register an account against Let's Encrypt."
+echo "For more information, see : https://letsencrypt.org"
+read -p "e-mail address: " acme_email
+sed -i -- 's/ACME_EMAIL=change_me@example.com/ACME_EMAIL='$acme_email'/g' .env
+echo ""
 
+echo "Please provide the domain from which SeAT have to be reachable (the base address, without slash or http(s) parts)"
+echo "ie: seat.yourdomain.com"
+read -p "domain: " host_address
+
+sed -i -- 's/HOST=change.me/HOST='$host_address'/g' .env
+sed -i -- 's/APP_URL=https:\/\/change.me/APP_URL=https:\/\/'$host_address'/g' .env
+sed -i -- 's/EVE_CALLBACK_URL=https:\/\/seat.yourdomain.com\/auth\/eve\/callback/EVE_CALLBACK_URL=https:\/\/'$host_address'\/auth\/eve\/callback/g' .env
+
+echo ""
 echo "Starting docker stack. This will download the images too. Please wait..."
+
 docker-compose up -d
 
-echo "Images downloaded. The containers are now iniliatising. To check what is happening, run 'docker-compose logs --tail 5 -f' in /opt/seat-docker"
-
+echo ""
+echo "Images downloaded. The containers are now initialising. To check what is happening, run 'docker-compose logs --tail 5 -f' in /opt/seat-docker"
+echo ""
 echo "Done!"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -44,17 +44,27 @@ services:
     container_name: seat-nginx
     restart: always
     environment:
-      - NGINX_HOST=${NGINX_HOST}
+      - NGINX_HOST=${HOST}
     volumes:
       - "seat-code:/var/www/seat"
       # Remove the comment below to enable nginx logs to disk.
       #- ./logs/nginx/:/var/log/nginx/
-    ports:
-      - "${NGINX_HTTP}:80"
-      - "${NGINX_HTTPS}:443"
-    command: /bin/sh -c "envsubst '${NGINX_HOST}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
+    command: /bin/sh -c "envsubst '${HOST}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
     networks:
       - seat-network
+      - traefik-network
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=docker-compose_traefik-network
+      - traefik.http.middlewares.seat-https-redirect.redirectscheme.scheme=https
+      - traefik.http.middlewares.seat-https-redirect.redirectscheme.permanent=true
+      - traefik.http.routers.seat.middlewares=seat-https-redirect
+      - traefik.http.routers.seat.entrypoints=seat
+      - traefik.http.routers.seat.rule=Host(`${HOST}`)
+      - traefik.http.routers.seat-secure.entrypoints=seat-secure
+      - traefik.http.routers.seat-secure.rule=Host(`${HOST}`)
+      - traefik.http.routers.seat-secure.tls=true
+      - traefik.http.routers.seat-secure.tls.certresolver=seat
     logging:
       driver: "json-file"
       options:
@@ -131,6 +141,40 @@ services:
         max-size: "10Mb"
         max-file: "5"
 
+  traefik:
+    image: traefik:v2.0
+    container_name: seat-traefik
+    restart: always
+    networks:
+      - traefik-network
+    ports:
+      - 80:80
+      - 8080:8080
+      - 443:443
+    depends_on:
+      - nginx
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.traefik.entrypoints=traefik
+      - traefik.http.routers.traefik.rule=Host(`localhost`)
+      - traefik.http.routers.traefik.service=api@internal
+    environment:
+      - TRAEFIK_API=true
+      - TRAEFIK_API_INSECURE=true
+      - TRAEFIK_API_DASHBOARD=true
+      - TRAEFIK_PROVIDERS_DOCKER=true
+      - TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT=false
+      - TRAEFIK_ENTRYPOINTS_seat=true
+      - TRAEFIK_ENTRYPOINTS_seat_ADDRESS=:80
+      - TRAEFIK_ENTRYPOINTS_seat-secure=true
+      - TRAEFIK_ENTRYPOINTS_seat-secure_ADDRESS=:443
+      - TRAEFIK_CERTIFICATESRESOLVERS_seat=true
+      - TRAEFIK_CERTIFICATESRESOLVERS_seat_ACME_EMAIL=${ACME_EMAIL}
+      - TRAEFIK_CERTIFICATESRESOLVERS_seat_ACME_HTTPCHALLENGE=true
+      - TRAEFIK_CERTIFICATESRESOLVERS_seat_ACME_HTTPCHALLENGE_ENTRYPOINT=seat
+
 volumes:
     seat-code:
     redis-data:
@@ -138,3 +182,4 @@ volumes:
 
 networks:
     seat-network:
+    traefik-network:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -82,8 +82,7 @@ services:
       - ./.env
     volumes:
       - "seat-code:/var/www/seat"
-      # Remove the comment below to enable SeAT logs to disk.
-      #- ./logs:/var/www/seat/storage/logs
+      - ./logs:/var/www/seat/storage/logs
     depends_on:
       - mariadb
       - redis

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -142,7 +142,7 @@ services:
         max-file: "5"
 
   traefik:
-    image: traefik:v2.0
+    image: traefik:v2.2
     container_name: seat-traefik
     restart: always
     networks:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -149,21 +149,12 @@ services:
       - traefik-network
     ports:
       - 80:80
-      - 8080:8080
       - 443:443
     depends_on:
       - nginx
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.traefik.entrypoints=traefik
-      - traefik.http.routers.traefik.rule=Host(`localhost`)
-      - traefik.http.routers.traefik.service=api@internal
     environment:
-      - TRAEFIK_API=true
-      - TRAEFIK_API_INSECURE=true
-      - TRAEFIK_API_DASHBOARD=true
       - TRAEFIK_PROVIDERS_DOCKER=true
       - TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT=false
       - TRAEFIK_ENTRYPOINTS_seat=true


### PR DESCRIPTION
to avoid end user troubles with proxy configuration, ship SeAT natively with traefik - so it will handle all the routing process including https.

this also prepare for potential SeAT 5 micro-services architecture.
so people who are coming from a SeAT 4 docker installation will already get a robust orchestrator ready.

**THIS IS RELATED TO SeAT V4 ONLY**